### PR TITLE
Use GHC 7.8.4 and Stackage LTS

### DIFF
--- a/build
+++ b/build
@@ -7,15 +7,15 @@ DOCKER_REGISTRY=$2
 DOCKER_OPTS=$3
 VERSION="$(date -u +%Y%m%d-%H%MZ)"
 IMAGE_NAME="${NAME}-${VERSION}"
-STACKAGE_URL=$(curl http://www.stackage.org/alias/fpcomplete/unstable-ghc78-inclusive -s -L -I -o /dev/null -w '%{url_effective}')
+STACKAGE_URL='http://www.stackage.org/lts/1.0'
 COMMIT=$(git rev-parse HEAD)
 FINGERPRINT="${COMMIT}${STACKAGE_URL}"
 
 if ! grep -q "^${FINGERPRINT}$" last-built; then
-  docker $DOCKER_OPTS pull $DOCKER_REGISTRY/afcowie/haskell
+  docker $DOCKER_OPTS pull $DOCKER_REGISTRY/afcowie/debian:jessie
   mkdir -p cache
   rsync -a src/ cache
-  docker $DOCKER_OPTS run -e STACKAGE_URL=$STACKAGE_URL --name="$IMAGE_NAME" -t -v ${PWD}/cache:/src:rw $DOCKER_REGISTRY/afcowie/haskell /src/install
+  docker $DOCKER_OPTS run -e STACKAGE_URL=$STACKAGE_URL --name="$IMAGE_NAME" -t -v ${PWD}/cache:/src:rw $DOCKER_REGISTRY/afcowie/debian:jessie /src/install
   docker $DOCKER_OPTS commit "$IMAGE_NAME" "$DOCKER_REGISTRY/engineering/${NAME}:${VERSION}"
   docker $DOCKER_OPTS rm "$IMAGE_NAME" || true
   docker $DOCKER_OPTS tag "$DOCKER_REGISTRY/engineering/${NAME}:${VERSION}" "$DOCKER_REGISTRY/engineering/${NAME}:latest"

--- a/src/apt-packages
+++ b/src/apt-packages
@@ -8,3 +8,17 @@ libpq5
 libpq-dev
 happy
 curl
+xz-utils
+autoconf
+automake
+libtool
+make
+libgmp-dev
+ncurses-dev
+g++
+llvm
+python
+bzip2
+zlib1g
+zlib1g-dev
+cabal-install

--- a/src/install
+++ b/src/install
@@ -2,26 +2,32 @@
 set +x
 set +e
 
+cd /src
+
+apt-get update
+apt-get dist-upgrade
+cat apt-packages | xargs apt-get install
+
+wget https://www.haskell.org/ghc/dist/7.8.4/ghc-7.8.4-x86_64-unknown-linux-deb7.tar.xz
+tar xf ghc-7.8.4-x86_64-unknown-linux-deb7.tar.xz
+cd ghc-7.8.4
+./configure
+make install
+
+mkdir /root/.cabal
 cp /src/.cabal/config /root/.cabal/config
 
 cd /src
 
-apt-get update
-cat apt-packages | xargs apt-get install
-
 cabal update
+wget "${STACKAGE_URL}/cabal.config?global=true"
+cat "cabal.config?global=true" >> /root/.cabal/config
 # Stackage still has an old version of mtl.
 # The packages responsible seem okay to ignore for us though.
 # https://github.com/fpco/stackage/issues/217
-cabal install --global 'mtl>=2.2'
-
-STACKAGE="remote-repo: stackage-ghc78-inc:${STACKAGE_URL}"
-
-sed -i -Ee "s#^remote-repo: (.*)\$#${STACKAGE}#" /root/.cabal/config
+sed -i -Ee "s#^constraint: mtl ==(.*)\$#constraint: mtl >=2.2.1#" /root/.cabal/config
+sed -i -Ee "s#^constraint: transformers (.*)\$#constraint: transformers ==0.4.*#" /root/.cabal/config
 cabal update
-
-# This is to prevent transformers 0.3
-cabal install --global 'transformers-compat' -f -three
 
 # alex, happy and other tools
 cat cabal-tools | tr "\n" "\0" | xargs -0 cabal install --global


### PR DESCRIPTION
With GHC 7.8.4, the existing Haskell image cannot be used to base this of any more. Instead a bare Debian image is used with the binary distribution of GHC.

Also Stackage doesn't include inclusive snapshots any more. Instead, the package constraints are put in directly in the cabal configuration.

This also includes the switch to Stackage LTS.
