### PR TITLE
Remove local cabal.config after copying to global

### DIFF
--- a/src/install
+++ b/src/install
@@ -29,6 +29,7 @@ cd /src
 
 wget "${STACKAGE_URL}/cabal.config?global=true" -O cabal.config
 cat "cabal.config" >> /root/.cabal/config
+rm cabal.config
 
 # snap-server supports SSL. This is turned off by default though.
 echo "constraint: snap-server +openssl" >> /root/.cabal/config


### PR DESCRIPTION
I think this stuff

```
Warning: /src/cabal.config: Unrecognized field constraint on line 1064
/src/cabal.config: Unrecognized field constraint on line 1063
...
```

is probably caused by the global cabal.config from wget still hanging around in the local directory.
